### PR TITLE
Adding known ignore()'s, updating README, and adding repeatedClassTransform config

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ in the folder where you run your code generation from.
 The default config looks like this:
 
 ```javascript
-module.exports {
+module.exports = {
   baseNamespace: 'proto',
   messageType: {
     '*': {
@@ -148,7 +148,7 @@ module.exports {
 If you want to include a certain mixin in a messageType class you can use this config:
 
 ```javascript
-module.exports {
+module.exports = {
   messageType: {
     'proto.api.MyMessage': {
       // relative to baseNamespace (starting with .)
@@ -161,7 +161,7 @@ module.exports {
 You can also use regular expression as class selectors:
 
 ```javascript
-module.exports {
+module.exports = {
   messageType: {
     '/proto.api.(MyMessage|MyOtherMessage)/': {
       // relative to baseNamespace (starting with .)

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ module.exports = {
   withoutSemi: false,
   // class to use for repeated properties
   repeatedClass: 'qx.data.Array',
+  // code to append to any repeatedClass reference to transform it into a plain array, if necessary (leave empty if no transform is necessary)
+  repeatedClassTransform: '.toArray()',
   // static classes that provide property validation methods (like qx.util.Validate)
   // these classes are registered in the proto.util.ValidationFactory
   validatorClasses: [],

--- a/config.js
+++ b/config.js
@@ -33,6 +33,8 @@ const defaultConfig = {
   withoutSemi: false,
   // class to use for repeated properties
   repeatedClass: 'qx.data.Array',
+  // code to append to any repeatedClass reference to transform it into a plain array, if necessary (leave empty if no transform is necessary)
+  repeatedClassTransform: '.toArray()',
   // static classes that provide property validation methods (like qx.util.Validate)
   // these classes are registered in the proto.util.ValidationFactory
   validatorClasses: [],

--- a/handlers/message.js
+++ b/handlers/message.js
@@ -22,6 +22,7 @@ function camelCase(object, capFirst) {
 handlebars.registerHelper('camel', camelCase);
 const {setPropEntry} = require('../utils')
 const arrayClass = config.get('repeatedClass')
+const repeatedClassTransform = config.get('repeatedClassTransform')
 const optionHandler = require('./options/index')
 
 const genTypeClass = (messageType, s, proto, relNamespace) => {

--- a/handlers/message.js
+++ b/handlers/message.js
@@ -145,7 +145,7 @@ const genTypeClass = (messageType, s, proto, relNamespace) => {
      * @returns {var|null} map value if the key exists in the map
      */
     get${camelCaseProp}ByKey: function (key) {
-      return this.get${camelCaseProp}().toArray().find(function (mapEntry) {
+      return this.get${camelCaseProp}()${repeatedClassTransform}.find(function (mapEntry) {
         return mapEntry.getKey() === key${lineEnd}
       }, this)${lineEnd}
     },
@@ -203,7 +203,7 @@ const genTypeClass = (messageType, s, proto, relNamespace) => {
             reader.readMessage(value, ${baseNamespace}${prop.typeName}.deserializeBinaryFromReader)${lineEnd}
             msg.set${camelCaseProp}(value)${lineEnd}
             break${lineEnd}`,
-          writerCode: list ? `f = message.get${camelCaseProp}().toArray()${lineEnd}
+          writerCode: list ? `f = message.get${camelCaseProp}()${repeatedClassTransform}${lineEnd}
       if (f != null) {
         writer.writeRepeatedMessage(
           ${prop.number},
@@ -278,7 +278,7 @@ const genTypeClass = (messageType, s, proto, relNamespace) => {
     } else if (propertyDefinition.type.pbType) {
       if (list) {
         const writeMethod = propertyDefinition.type.packed ? `writePacked${propertyDefinition.type.pbType}` : `writeRepeated${propertyDefinition.type.pbType}`
-        propertyDefinition.serializer.push(`f = message.get${camelCaseProp}().toArray()${lineEnd}
+        propertyDefinition.serializer.push(`f = message.get${camelCaseProp}()${repeatedClassTransform}${lineEnd}
       if (f${propertyDefinition.type.emptyComparison}) {
         writer.${writeMethod}(
           ${prop.number},

--- a/handlers/message.js
+++ b/handlers/message.js
@@ -43,7 +43,8 @@ const genTypeClass = (messageType, s, proto, relNamespace) => {
   const context = {
     requirements: [],
     ignores: [
-      'google.protobuf'
+      'proto.google.protobuf',
+      'jspb'
     ],
     includes: config.getIncludes('messageType', classNamespace).slice(),
     implements: config.getImplements('messageType', classNamespace).slice(),

--- a/handlers/message.js
+++ b/handlers/message.js
@@ -42,7 +42,9 @@ const genTypeClass = (messageType, s, proto, relNamespace) => {
   // all the information needed to generate the code
   const context = {
     requirements: [],
-    ignores: [],
+    ignores: [
+      'google.protobuf'
+    ],
     includes: config.getIncludes('messageType', classNamespace).slice(),
     implements: config.getImplements('messageType', classNamespace).slice(),
     constructor: [],
@@ -189,8 +191,6 @@ const genTypeClass = (messageType, s, proto, relNamespace) => {
         } else if (prop.typeName === '.google.protobuf.Any') {
           // add requirement
           context.requirements.push(`@require(${baseNamespace}${prop.typeName})`)
-          // add ignores
-          context.ignores.push(`@ignore(${baseNamespace}${prop.typeName}.*)`)
         }
         propertyDefinition.type = {
           qxType: `${qxType}`,

--- a/handlers/message.js
+++ b/handlers/message.js
@@ -43,8 +43,7 @@ const genTypeClass = (messageType, s, proto, relNamespace) => {
   const context = {
     requirements: [],
     ignores: [
-      'proto.google.protobuf',
-      'jspb'
+      '@ignore(jspb, proto.google.protobuf)'
     ],
     includes: config.getIncludes('messageType', classNamespace).slice(),
     implements: config.getImplements('messageType', classNamespace).slice(),


### PR DESCRIPTION
`jspb` is always used in the generated code I believe, so I've added it to always be present in the `@ignores()`. `proto.google.protobuf` may not always be used in the generated code but it is in at least my case, so I added it as well. I looked at adding it conditionally but that code section in `handlers/message.js` is pretty dense and the logic wasn't obvious.

Finally, most of the code snippets in the README were missing the `=` after `module.exports`, so I fixed that.